### PR TITLE
Finalize 2.13 build:

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -118,10 +118,13 @@ lazy val benchmarks = project.module
   .enablePlugins(JmhPlugin)
   .settings(replSettings)
   .settings(
+    // skip 2.13 benchmarks until monix & twitter-util publish for 2.13
+    crossScalaVersions -= "2.13.0",
+    //
     skip in publish := true,
     libraryDependencies ++=
       Seq(
-        "co.fs2"                   %% "fs2-core"        % "1.0.5",
+        "co.fs2"                   %% "fs2-core"        % "1.1.0-M1",
         "com.google.code.findbugs" % "jsr305"           % "3.0.2",
         "com.twitter"              %% "util-collection" % "19.1.0",
         "com.typesafe.akka"        %% "akka-stream"     % "2.5.23",
@@ -131,7 +134,7 @@ lazy val benchmarks = project.module
         "org.ow2.asm"              % "asm"              % "7.1",
         "org.scala-lang"           % "scala-compiler"   % scalaVersion.value % Provided,
         "org.scala-lang"           % "scala-reflect"    % scalaVersion.value,
-        "org.typelevel"            %% "cats-effect"     % "1.3.1"
+        "org.typelevel"            %% "cats-effect"     % "2.0.0-M4"
       ),
     unusedCompileDependenciesFilter -= libraryDependencies.value
       .map(moduleid => moduleFilter(organization = moduleid.organization, name = moduleid.name))
@@ -149,6 +152,9 @@ lazy val benchmarks = project.module
 lazy val docs = project.module
   .in(file("zio-docs"))
   .settings(
+    // skip 2.13 mdoc until mdoc is available for 2.13
+    crossScalaVersions -= "2.13.0",
+    //
     skip.in(publish) := true,
     moduleName := "zio-docs",
     unusedCompileDependenciesFilter -= moduleFilter("org.scalameta", "mdoc"),

--- a/core/shared/src/main/scala/zio/Cause.scala
+++ b/core/shared/src/main/scala/zio/Cause.scala
@@ -120,9 +120,9 @@ sealed trait Cause[+E] extends Product with Serializable { self =>
         case _                         => causeToSequential(cause).all
       }
 
-    // Java 11 defines String#lines returning a Stream<String>, so the implicit conversion has to
-    // be requested explicitly
-    def lines(str: String): List[String] = augmentString(str).lines.toList
+    // Inline definition of `StringOps.lines` to avoid calling either of `.linesIterator` or `.lines`
+    // since both are deprecated in either 2.11 or 2.13 respectively.
+    def lines(str: String): List[String] = augmentString(str).linesWithSeparators.map(_.stripLineEnd).toList
 
     def renderThrowable(e: Throwable): List[String] = {
       import java.io.{ PrintWriter, StringWriter }

--- a/core/shared/src/main/scala/zio/internal/FiberContext.scala
+++ b/core/shared/src/main/scala/zio/internal/FiberContext.scala
@@ -17,8 +17,10 @@
 package zio.internal
 
 import java.util.concurrent.atomic.{ AtomicLong, AtomicReference }
-import scala.collection.JavaConverters._
 
+import com.github.ghik.silencer.silent
+
+import scala.collection.JavaConverters._
 import zio.internal.FiberContext.{ FiberRefLocals, SuperviseStatus }
 import zio.Cause
 import zio._
@@ -610,7 +612,7 @@ private[zio] final class FiberContext[E, A](
   final def poll: UIO[Option[Exit[E, A]]] = ZIO.effectTotal(poll0)
 
   final def inheritFiberRefs: UIO[Unit] = UIO.suspend {
-    val locals = fiberRefLocals.asScala
+    val locals = fiberRefLocals.asScala: @silent("JavaConverters")
     if (locals.isEmpty) UIO.unit
     else
       UIO.foreach_(locals) {

--- a/core/shared/src/main/scala/zio/stm/STM.scala
+++ b/core/shared/src/main/scala/zio/stm/STM.scala
@@ -20,8 +20,10 @@ import java.util.concurrent.atomic.{ AtomicBoolean, AtomicLong }
 
 import zio.{ IO, UIO }
 import zio.internal.Platform
-
 import java.util.{ HashMap => MutableMap }
+
+import com.github.ghik.silencer.silent
+
 import scala.util.{ Failure, Success, Try }
 import scala.annotation.tailrec
 
@@ -401,7 +403,7 @@ object STM {
 
           loop = !todo.compareAndSet(oldTodo, emptyTodo)
 
-          if (!loop) allTodos.putAll(oldTodo.asJava)
+          if (!loop) allTodos.putAll(oldTodo.asJava): @silent("JavaConverters")
         }
       }
 

--- a/core/shared/src/main/scala/zio/stm/TQueue.scala
+++ b/core/shared/src/main/scala/zio/stm/TQueue.scala
@@ -16,6 +16,8 @@
 
 package zio.stm
 
+import com.github.ghik.silencer.silent
+
 import scala.collection.immutable.{ Queue => ScalaQueue }
 
 class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
@@ -27,6 +29,7 @@ class TQueue[A] private (val capacity: Int, ref: TRef[ScalaQueue[A]]) {
     } yield ()
 
   // TODO: Scala doesn't allow Iterable???
+  @silent("enqueueAll")
   final def offerAll(as: List[A]): STM[Nothing, Unit] =
     ref.update(_.enqueue(as)).unit
 

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -130,7 +130,7 @@ object BuildHelper {
   def stdSettings(prjName: String) = Seq(
     name := s"$prjName",
     scalacOptions := stdOptions,
-    crossScalaVersions := Seq("2.13.0", "2.12.8", "2.11.12"),
+    crossScalaVersions := Seq("2.12.8", "2.13.0", "2.11.12"),
     scalaVersion in ThisBuild := crossScalaVersions.value.head,
     scalacOptions := stdOptions ++ extraOptions(scalaVersion.value, optimize = !isSnapshot.value),
     libraryDependencies ++= compileOnlyDeps ++ testDeps,
@@ -147,16 +147,25 @@ object BuildHelper {
     Compile / unmanagedSourceDirectories ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, x)) if x <= 11 =>
-          CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.11")) ++
+          Seq(
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.11")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.11"))
+          ).flatten
         case Some((2, x)) if x >= 12 =>
-          CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")) ++
+          Seq(
+            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12")),
+            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12+")),
+            CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")),
             CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.12+"))
+          ).flatten
         case _ =>
           if (isDotty.value)
-            Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12")) ++
-              CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")) ++
+            Seq(
+              Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12")),
+              Seq(file(sourceDirectory.value.getPath + "/main/scala-2.12+")),
+              CrossType.Full.sharedSrcDir(baseDirectory.value, "main").toList.map(f => file(f.getPath + "-2.12+")),
               CrossType.Full.sharedSrcDir(baseDirectory.value, "test").toList.map(f => file(f.getPath + "-2.12+"))
+            ).flatten
           else
             Nil
       }


### PR DESCRIPTION
* inline `linesIterator` implementation to avoid calling either lines or linesIterator deprecated methods
* silence JavaConverters and Queue.enqueue warnings, since they won't be removed during 2.13 cycle
* disable benchmarks and mdoc for 2.13, since mdoc & benchmark dependencies are not available yet

https://github.com/zio/zio/pull/1104